### PR TITLE
Feature commonjs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "main": "src/angular-dragdrop.js",
   "dependencies": {},
   "devDependencies": {
-    "jasmine-core": "^2.2.0",
-    "karma": "^0.12.31",
-    "karma-chrome-launcher": "^0.1.7",
-    "karma-jasmine": "^0.3.5"
+    "jasmine-core": "^2.8.0",
+    "karma": "^1.7.1",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-jasmine": "^1.1.0"
   },
   "scripts": {
     "test": "npm run test-unit",

--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -27,7 +27,7 @@
  * (c) 2013 Amit Gharat a.k.a codef0rmer <amit.2006.it@gmail.com> - amitgharat.wordpress.com
  */
 
-(function (window, angular, $, undefined) {
+(function (angular, $, undefined) {
 'use strict';
 
 var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$timeout', '$parse', '$q', function($timeout, $parse, $q) {
@@ -173,7 +173,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
     this.move = function($fromEl, $toEl, toPos, duration, dropSettings, callback) {
       if ($fromEl.length === 0) {
         if (callback) {
-          window.setTimeout(function() {
+          $timeout(function() {
             callback();
           }, 300);
         }
@@ -416,4 +416,4 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
 
     return element.getAttribute(name) || element.getAttribute('data-' + name);
   };
-})(window, window.angular, window.jQuery);
+})(window.angular, window.jQuery);

--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -27,6 +27,10 @@
  * (c) 2013 Amit Gharat a.k.a codef0rmer <amit.2006.it@gmail.com> - amitgharat.wordpress.com
  */
 
+
+ // indicates if environment is or emulates commonjs
+ var commonJsLikeEnv = typeof require === 'function';
+
 (function (angular, $, undefined) {
 'use strict';
 
@@ -416,4 +420,4 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
 
     return element.getAttribute(name) || element.getAttribute('data-' + name);
   };
-})(window.angular, window.jQuery);
+})(commonJsLikeEnv ? require('angular') : window.angular, commonJsLikeEnv ? require('jquery') : window.jQuery);


### PR DESCRIPTION
Adds code to support module bundlers for the web (such as `webpack` and `browserify`).
    
If `require` function is available, it's used to import `angular` and `jquery` dependencies. Otherwise it looks for them in `window`.

Additionally, `karma` dependency was updated since 0.X version don't support node 7.X (or superior).
